### PR TITLE
Blacksmith lockpicking support

### DIFF
--- a/Lockpicking.lua
+++ b/Lockpicking.lua
@@ -36,3 +36,26 @@ local openable = {
 function ns.Openable(link)
 	return openable[link:match('item:(%d+)')]
 end
+
+
+-- Blacksmith Lockpicking
+
+local keys = {
+	(GetSpellInfo(130100)), -- Ghostly
+	(GetSpellInfo(94574)), -- Obsidium
+	(GetSpellInfo(59403)), -- Titanium
+	(GetSpellInfo(59404)), -- Colbat
+	(GetSpellInfo(20709)), -- Arcanite
+	(GetSpellInfo(19651)), -- Truesilver
+	(GetSpellInfo(19649)), -- Golden
+	(GetSpellInfo(19646)), -- Silver
+}
+
+-- find the highest level key in your bags
+function ns.SkeletonKey(link)
+	for _,v in ipairs(keys) do
+		if GetItemCount(v) > 0 then
+			return v
+		end
+	end
+end

--- a/Molinari.lua
+++ b/Molinari.lua
@@ -14,7 +14,7 @@ local function ScanTooltip(self, spells)
 end
 
 function button:PLAYER_LOGIN()
-	local spells, disenchanter, rogue = {}
+	local spells, disenchanter, rogue, smith = {}
 	if(IsSpellKnown(51005)) then
 		spells[ITEM_MILLABLE] = {GetSpellInfo(51005), 1/2, 1, 1/2}
 	end
@@ -24,13 +24,9 @@ function button:PLAYER_LOGIN()
 	end
 
 	-- I wish Blizzard could treat disenchanting the same way
-	if(IsSpellKnown(13262)) then
-		disenchanter = true
-	end
-
-	if(IsSpellKnown(1804)) then
-		rogue = true
-	end
+	disenchanter = IsSpellKnown(13262)
+	rogue = IsSpellKnown(1804)
+	smith = GetSpellBookItemInfo((GetSpellInfo(2018))) and true
 
 	GameTooltip:HookScript('OnTooltipSetItem', function(self)
 		local item, link = self:GetItem()
@@ -43,6 +39,10 @@ function button:PLAYER_LOGIN()
 
 			if(not spell and rogue and ns.Openable(link)) then
 				spell, r, g, b = GetSpellInfo(1804), 0, 1, 1
+			end
+
+			if(not spell and smith and ns.Openable(link)) then
+				spell, r, g, b = ns.SkeletonKey(link), 0, 1, 1
 			end
 
 			if(not spell) then


### PR DESCRIPTION
Adds support to open lock boxes with skeleton keys if you're a blacksmith. Simply picks the highest level key in your bags and uses it as the action spell
