### PR TITLE
Add guards for nil errors in Molinari:GetBagAndSlotID()

### DIFF
--- a/Molinari.lua
+++ b/Molinari.lua
@@ -99,17 +99,17 @@ end
 function Molinari:GetBagAndSlotID()
 	local parent = GetMouseFocus()
 	local bagID, slotID
-	if parent.GetSlotAndBagID then
+	if parent and parent.GetSlotAndBagID then
 		-- this is the preferred API to use, added in Dragonflight, as it's 100% accurate
 		slotID, bagID = parent:GetSlotAndBagID()
-	elseif parent.GetBagID then
+	elseif parent and parent.GetBagID then
 		-- the above is preferred
 		bagID = parent:GetBagID()
 		slotID = parent:GetID()
 	else
 		-- this is a complete guesswork, bag addons should implement one of the two above APIs
-		bagID = parent:GetParent():GetID()
-		slotID = parent:GetID()
+		bagID = parent and parent:GetParent() and parent:GetParent():GetID()
+		slotID = parent and parent:GetID()
 	end
 
 	if bagID and bagID >= 0 and slotID and slotID >= 0 then


### PR DESCRIPTION
If ``parent`` is nil then the addon will throw a Lua error.

This might happen when interacting with some other addons such as OPie, when holding Molinari's modifier key and clicking on an item based action button.

Not sure if there is a more elegant solution, but after a lot of testing it seems to work without any issues. I get no errors in OPie and I'm still able to use Molinari where expected.